### PR TITLE
Adding link to pull requests and bumping version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Pull Request Notifier",
   "description": "Keep track of the Pull Requests of your favorite repositories <3",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "icons": { "16": "github-120.png",
            "48": "github-120.png",
           "128": "github-120.png" },

--- a/popup.html
+++ b/popup.html
@@ -5,7 +5,7 @@
     <script type="text/html" id="repository-row">
     <li data-id="{{name}}">
         <p>
-          <a href="{{git_host}}/{{name}}" target="_blank">{{name}}</a><span class="remove">x</span>
+          <a href="{{git_host}}/{{name}}" target="_blank">{{name}}</a> (<a href="{{git_host}}/{{name}}/pulls" target="_blank">pulls</a>)<span class="remove">x</span>
         </p>
         <ul class="prs">{{pullRequests}}</ul>
       </li>
@@ -53,7 +53,7 @@
       <p>
         <label for="github-apihost">Github API Host</label>
       </p>
-      <p>        
+      <p>
         <input type="text" name="github-apihost" id="github-apihost" placeholder="https://api.github.com"/>
       </p>
       <p>


### PR DESCRIPTION
I noticed when I dragged the repo version of the extension into Chrome I got the notification working, so I figured a version bump was in order as well.

The feature I added is pretty simple:

![2015-03-13 at 3 09 pm](https://cloud.githubusercontent.com/assets/8973794/6647360/15918de2-c993-11e4-8f85-ccc3dbbbf17d.png)

Something I find myself doing fairly regularly is going to the pull request page itself. I added a convenience link to that area. The 'x' to remove still works as expected.